### PR TITLE
Only copy .env.example to .env if .env doesn't exist.

### DIFF
--- a/bin/postinstall
+++ b/bin/postinstall
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+
+const ncp = require('ncp').ncp;
+
+ncp(
+  '.env.example',
+  '.env',
+  {
+    clobber: false
+  },
+  function(err) {
+    if (Array.isArray(err)) {
+      console.error('There were errors during the copy.');
+      err.forEach(function(err) {
+        console.error(err.stack || err.message);
+      });
+      process.exit(1);
+    } else if (err) {
+      console.error('An error has occurred.');
+      console.error(err.stack || err.message);
+      process.exit(1);
+    }
+  }
+);

--- a/package.json
+++ b/package.json
@@ -6,10 +6,9 @@
   "scripts": {
     "start:prod": "node .",
     "start:dev": "node-env-run -f .",
-    "start":
-      "if-env NODE_ENV=production ?? npm run start:prod || npm run start:dev",
+    "start": "if-env NODE_ENV=production ?? npm run start:prod || npm run start:dev",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "postinstall": "ncp .env.example .env"
+    "postinstall": "./bin/postinstall"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This uses the programmatic version of ncp because the --clobber option is not available to the command line version.

The error handling and return code is copied from the ncp binary as it's all very similar really.